### PR TITLE
Allow configure experimental mode

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,6 +23,7 @@ Host
     docker:
       host:
         enabled: true
+        experimental: true
         insecure_registries:
           - 127.0.0.1
         log:

--- a/docker/files/daemon.json
+++ b/docker/files/daemon.json
@@ -1,5 +1,9 @@
 {% from "docker/map.jinja" import host with context %}
 {
+  {%- if host.experimental is defined %}
+  "experimental": {{ host.experimental|lower }}
+  {%- if host.insecure_registries is defined %},{% endif %}
+  {%- endif %}
   {%- if host.insecure_registries is defined %}
   "insecure-registries": [
     {%- for registry in host.insecure_registries %}


### PR DESCRIPTION
Experimental mode allows to see logs of a swarm service,
e.g. docker service logs <service_id>