### PR TITLE
Add support for --hostname docker service flag

### DIFF
--- a/docker/files/daemon.json
+++ b/docker/files/daemon.json
@@ -1,5 +1,9 @@
 {% from "docker/map.jinja" import host with context %}
 {
+  {%- if host.bip is defined %}
+  "bip": "{{ host.bip }}"
+  {%- if host.experimental is defined %},{% endif %}
+  {%- endif %}
   {%- if host.experimental is defined %}
   "experimental": {{ host.experimental|lower }}
   {%- if host.insecure_registries is defined %},{% endif %}


### PR DESCRIPTION
Added support for `--hostname` service flag.

Example pillar:
```yaml
parameters:
  docker:
    client:
      service:
        gitlab:
          hostname: gitlab.mydomain.tld
```

will generate command:

```
docker service create --name gitlab <other args> --hostname gitlab.mydomain.tld <other args>
```