### PR TITLE
Multiple service constraints.  Volumes logic in stack state.  Added configs key to docker-compose.yml.

### DIFF
--- a/docker/client/service.sls
+++ b/docker/client/service.sls
@@ -35,8 +35,9 @@ docker_service_{{ name }}_create:
         {%- if service.workdir is defined %} --workdir {{ service.workdir }}{%- endif %}
         {%- if service.mode is defined %} --mode {{ service.mode }}{%- endif %}
         {%- if service.endpoint is defined %} --endpoint-mode {{ service.endpoint }}{%- endif %}
-        {%- if service.constraint is defined %} --constraint {{ service.constraint }}{%- endif %}
         {%- if service.hostname is defined %} --hostname {{ service.hostname }}{%- endif %}
+        {%- if service.constraint is defined %} --constraint {{ service.constraint }}{%- endif %}
+        {%- for constraint in service.get('constraints', []) %} --constraint {{ constraint }}{%- endfor %}
         {%- for name, volume in service.get('volume', {}).iteritems() %} --mount {% for key, value in volume.iteritems() %}{{ key }}={{ value }}{% if not loop.last %},{% endif %}{% endfor %}{%- endfor %}
         {%- for param, value in service.get('restart', {}).iteritems() %} --restart-{{ param }} {{ value }}{%- endfor %}
         {%- for param, value in service.get('update', {}).iteritems() %} --update-{{ param }} {{ value }}{%- endfor %}

--- a/docker/client/stack.sls
+++ b/docker/client/stack.sls
@@ -56,7 +56,7 @@ docker_{{ app }}_env:
           {%- set path = None %}
         {%- endif %}
 
-        {%- if path != None and path not in compose.volume.keys() %}
+        {%- if path != None and path not in compose.get('volume', {}).keys() %}
 docker_{{ app }}_{{ name }}_volume_{{ path }}:
   file.directory:
     - name: {{ path }}

--- a/docker/client/stack.sls
+++ b/docker/client/stack.sls
@@ -52,9 +52,11 @@ docker_{{ app }}_env:
           {%- set path = volume.split(':')[0] %}
         {%- elif volume is mapping and volume.get('type', 'bind') == 'bind' %}
           {%- set path = volume.source %}
+        {%- else %}
+          {%- set path = None %}
         {%- endif %}
 
-        {%- if path is defined %}
+        {%- if path != None and path not in compose.volume.keys() %}
 docker_{{ app }}_{{ name }}_volume_{{ path }}:
   file.directory:
     - name: {{ path }}

--- a/docker/files/docker-compose.yml
+++ b/docker/files/docker-compose.yml
@@ -1,5 +1,10 @@
 version: '{{ compose.version|default("3") }}'
 
+{%- if compose.config|default({}) %}
+configs:
+  {{ compose.config|yaml(False)|indent(2) }}
+{%- endif %}
+
 services:
   {%- for name, srv in service.iteritems() %}
   {%- set env_file_set = False %}


### PR DESCRIPTION
This pull request does the following:

1. Adds the option to set multiple constraints in a swarm service.

2. Fixes the stack state so it will not attempt to create a directory for a volume mount.  Previously if a bind mount was first defined in a map and a volume mount in a map followed, the path would still be defined and therefore a directory is attempted to be created.  Also, now it will not attempt to create a directory for volumes specified in the stack.

3. Adds the new "configs" key to docker-compose.yml.
https://docs.docker.com/compose/compose-file/#configs

Cheers!
Doug
