### PR TITLE
Debian docker repo has docker-engine package

### DIFF
--- a/docker/map.jinja
+++ b/docker/map.jinja
@@ -5,7 +5,7 @@
         'service': 'docker',
     },
     'Debian': {
-        'pkgs': ['docker.io'],
+        'pkgs': ['docker-engine'],
         'service': 'docker',
     },
     'RedHat': {


### PR DESCRIPTION
Changed pkgs for Debian from `docker-io` to `docker-engine`. its the only package available in https://apt.dockerproject.org/repo/ for Debian.