### PR TITLE
change docker-io pkg to docker on centos

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,6 +19,12 @@ Docker host configuration samples
 
     docker:
       host:
+        pkgs:
+          - docker-ce-selinux: 17.03.2.ce-1-el7.centos
+          - docker-ce: 17.03.2.ce-1-el7.centos
+        hold: true
+        update_holds: true
+        setopt: obsoletes=0
         enabled: true
         options:
           bip: 172.31.255.1/16

--- a/README.rst
+++ b/README.rst
@@ -24,7 +24,8 @@ Docker host configuration samples
           - docker-ce: 17.03.2.ce-1-el7.centos
         hold: true
         update_holds: true
-        setopt: obsoletes=0
+        setopt: 
+          - obsoletes=0
         enabled: true
         options:
           bip: 172.31.255.1/16

--- a/docker/host.sls
+++ b/docker/host.sls
@@ -5,6 +5,7 @@
 docker_packages:
   pkg.installed:
   - pkgs: {{ host.pkgs }}
+  - version: {{ host.version }}
 
 {%- if grains.get('virtual_subtype', None) not in ['Docker', 'LXC'] %}
 

--- a/docker/host.sls
+++ b/docker/host.sls
@@ -5,7 +5,6 @@
 docker_packages:
   pkg.installed:
   - pkgs: {{ host.pkgs }}
-  - version: {{ host.version }}
 
 {%- if grains.get('virtual_subtype', None) not in ['Docker', 'LXC'] %}
 

--- a/docker/host.sls
+++ b/docker/host.sls
@@ -5,6 +5,9 @@
 docker_packages:
   pkg.installed:
   - pkgs: {{ host.pkgs }}
+  - hold: {{ host.hold }}
+  - update_holds: {{ host.update_holds }}
+  - setopt: {{ host.setopt }}
 
 {%- if grains.get('virtual_subtype', None) not in ['Docker', 'LXC'] %}
 

--- a/docker/map.jinja
+++ b/docker/map.jinja
@@ -3,18 +3,22 @@
     'CentOS': {
         'pkgs': ['docker'],
         'service': 'docker',
+        'version': 'latest',
     },
     'Debian': {
         'pkgs': ['docker.io'],
         'service': 'docker',
+        'version': 'latest',
     },
     'RedHat': {
         'pkgs': ['iptables', 'lxc-docker'],
         'service': 'docker',
+        'version': 'latest',
     },
     'Ubuntu': {
         'pkgs': ['docker-engine', 'python-docker'],
         'service': 'docker',
+        'version': 'latest',
     },
 }, grain='os', merge=salt['pillar.get']('docker:host')) %}
 

--- a/docker/map.jinja
+++ b/docker/map.jinja
@@ -1,7 +1,7 @@
 
 {% set host = salt['grains.filter_by']({
     'CentOS': {
-        'pkgs': ['docker-io'],
+        'pkgs': ['docker'],
         'service': 'docker',
     },
     'Debian': {

--- a/docker/map.jinja
+++ b/docker/map.jinja
@@ -3,6 +3,9 @@
     'CentOS': {
         'pkgs': ['docker'],
         'service': 'docker',
+        'hold': 'false',
+        'update_holds': 'false',
+        'setopt': ['obsoletes=1'],
     },
     'Debian': {
         'pkgs': ['docker.io'],

--- a/docker/map.jinja
+++ b/docker/map.jinja
@@ -3,22 +3,18 @@
     'CentOS': {
         'pkgs': ['docker'],
         'service': 'docker',
-        'version': 'latest',
     },
     'Debian': {
         'pkgs': ['docker.io'],
         'service': 'docker',
-        'version': 'latest',
     },
     'RedHat': {
         'pkgs': ['iptables', 'lxc-docker'],
         'service': 'docker',
-        'version': 'latest',
     },
     'Ubuntu': {
         'pkgs': ['docker-engine', 'python-docker'],
         'service': 'docker',
-        'version': 'latest',
     },
 }, grain='os', merge=salt['pillar.get']('docker:host')) %}
 


### PR DESCRIPTION
Yum search docker-io on centos 7.5 returns:
Warning: No matches found for: docker-io
No matches found

With and without docker-ce repo installed.