### PR TITLE
cmd.run user, service params, stack registry auth, extension-fields, password in env var

### DIFF
--- a/docker/client/service.sls
+++ b/docker/client/service.sls
@@ -36,11 +36,15 @@ docker_service_{{ name }}_create:
         {%- if service.mode is defined %} --mode {{ service.mode }}{%- endif %}
         {%- if service.endpoint is defined %} --endpoint-mode {{ service.endpoint }}{%- endif %}
         {%- if service.hostname is defined %} --hostname {{ service.hostname }}{%- endif %}
+        {%- if service.placement_pref is defined %} --placement-pref {{ service.placement_pref }}{%- endif %}
         {%- if service.constraint is defined %} --constraint {{ service.constraint }}{%- endif %}
         {%- for constraint in service.get('constraints', []) %} --constraint {{ constraint }}{%- endfor %}
         {%- for name, volume in service.get('volume', {}).iteritems() %} --mount {% for key, value in volume.iteritems() %}{{ key }}={{ value }}{% if not loop.last %},{% endif %}{% endfor %}{%- endfor %}
+        {%- for param, value in service.get('stop', {}).iteritems() %} --stop-{{ param }} {{ value }}{%- endfor %}
         {%- for param, value in service.get('restart', {}).iteritems() %} --restart-{{ param }} {{ value }}{%- endfor %}
         {%- for param, value in service.get('update', {}).iteritems() %} --update-{{ param }} {{ value }}{%- endfor %}
+        {%- for param, value in service.get('rollback', {}).iteritems() %} --rollback-{{ param }} {{ value }}{%- endfor %}
+        {%- for param, value in service.get('health', {}).iteritems() %} --health-{{ param }} {{ value }}{%- endfor %}
         {%- for param, value in service.get('log', {}).iteritems() %} --log-{{ param }} {{ value }}{%- endfor %}
         {%- for param, value in service.get('limit', {}).iteritems() %} --limit-{{ param }} {{ value }}{%- endfor %}
         {%- for param, value in service.get('reserve', {}).iteritems() %} --reserve-{{ param }} {{ value }}{%- endfor %}
@@ -69,8 +73,11 @@ docker_service_{{ name }}_update:
         {%- if service.user is defined %} --user {{ service.user }}{%- endif %}
         {%- if service.workdir is defined %} --workdir {{ service.workdir }}{%- endif %}
         {%- if service.endpoint is defined %} --endpoint-mode {{ service.endpoint }}{%- endif %}
+        {%- for param, value in service.get('stop', {}).iteritems() %} --stop-{{ param }} {{ value }}{%- endfor %}
         {%- for param, value in service.get('restart', {}).iteritems() %} --restart-{{ param }} {{ value }}{%- endfor %}
         {%- for param, value in service.get('update', {}).iteritems() %} --update-{{ param }} {{ value }}{%- endfor %}
+        {%- for param, value in service.get('rollback', {}).iteritems() %} --rollback-{{ param }} {{ value }}{%- endfor %}
+        {%- for param, value in service.get('health', {}).iteritems() %} --health-{{ param }} {{ value }}{%- endfor %}
         {%- for param, value in service.get('log', {}).iteritems() %} --log-{{ param }} {{ value }}{%- endfor %}
         {%- for param, value in service.get('limit', {}).iteritems() %} --limit-{{ param }} {{ value }}{%- endfor %}
         {%- for param, value in service.get('reserve', {}).iteritems() %} --reserve-{{ param }} {{ value }}{%- endfor %}

--- a/docker/client/stack.sls
+++ b/docker/client/stack.sls
@@ -74,7 +74,7 @@ docker_stack_{{ app }}:
         retry=5
         i=1;
         while [[ $i -lt $retry ]]; do
-          docker stack deploy --compose-file docker-compose.yml {{ app }};
+          docker stack deploy --compose-file docker-compose.yml --with-registry-auth {{ app }};
           ret=$?;
           if [[ $ret -eq 0 ]]; then echo 'Stack created'; break;
           else
@@ -88,7 +88,7 @@ docker_stack_{{ app }}:
         done;
     - shell: /bin/bash
     - cwd: {{ client.compose.base }}/{{ app }}
-    - user: {{ compose.user|default("root") }}
+    - runas: {{ compose.user|default("root") }}
     - unless: "docker stack ls | grep '{{ app }}'"
     - require:
       - file: docker_{{ app }}_env
@@ -100,7 +100,7 @@ docker_stack_{{ app }}_update:
         retry=5
         i=1;
         while [[ $i -lt $retry ]]; do
-          docker stack deploy --compose-file docker-compose.yml {{ app }};
+          docker stack deploy --compose-file docker-compose.yml --with-registry-auth {{ app }};
           ret=$?;
           if [[ $ret -eq 0 ]]; then echo 'Stack updated'; break;
           else
@@ -114,7 +114,7 @@ docker_stack_{{ app }}_update:
         done;
     - shell: /bin/bash
     - cwd: {{ client.compose.base }}/{{ app }}
-    - user: {{ compose.user|default("root") }}
+    - runas: {{ compose.user|default("root") }}
     - require:
       - cmd: docker_stack_{{ app }}
     - watch:
@@ -126,7 +126,7 @@ docker_stack_{{ app }}_update:
 docker_remove_{{ app }}:
   cmd.run:
     - name: docker stack rm {{ app }}
-    - user: {{ compose.user|default("root") }}
+    - runas: {{ compose.user|default("root") }}
     - onlyif: "docker stack ls | grep '{{ app }}'"
 
     {%- endif %}

--- a/docker/files/docker-compose.yml
+++ b/docker/files/docker-compose.yml
@@ -5,6 +5,11 @@ configs:
   {{ compose.config|yaml(False)|indent(2) }}
 {%- endif %}
 
+{%- for key, value in compose.items() if key.startswith('x-') %}
+{{ key }}:
+  {{ value|yaml(False)|indent(2) }}
+{%- endfor %}
+
 services:
   {%- for name, srv in service.iteritems() %}
   {%- set env_file_set = False %}

--- a/docker/host.sls
+++ b/docker/host.sls
@@ -83,8 +83,10 @@ docker_service:
 
 docker_{{ registry.get('address', name) }}_login:
   cmd.run:
-  - name: 'docker login -u {{ registry.user }} -p {{ registry.password }}{% if registry.get('address') %} {{ registry.address }}{% endif %}'
-  - user: {{ registry.get('system_user', 'root') }}
+  - name: 'docker login -u {{ registry.user }} -p $REGISTRY_PASSWORD{% if registry.get('address') %} {{ registry.address }}{% endif %}'
+  - env:
+      REGISTRY_PASSWORD: {{ registry.password }}
+  - runas: {{ registry.get('system_user', 'root') }}
   - unless: grep {{ registry.address|default('https://index.docker.io/v1/') }} {{ salt['user.info'](registry.get('system_user', 'root')).home }}/.docker/config.json
 
 {%- endfor %}

--- a/docker/swarm.sls
+++ b/docker/swarm.sls
@@ -69,10 +69,12 @@ docker_swarm_join:
   cmd.run:
     - name: >
         docker swarm join
-        --token {{ join_token }}
+        --token $JOIN_TOKEN
         {%- if swarm.advertise_addr is defined %} --advertise-addr {{ swarm.advertise_addr }}{%- endif %}
         {%- if swarm.get('bind', {}).get('address', None) %} --listen-addr {{ swarm.bind.address }}{% if swarm.bind.port is defined %}:{{ swarm.bind.port }}{% endif %}{%- endif %}
         {{ swarm.master.host }}:{{ swarm.master.port }}
+    - env:
+        JOIN_TOKEN: {{ join_token }}
     - unless:
       - "test -e /var/lib/docker/swarm/state.json"
       - "grep -q node_id /var/lib/docker/swarm/state.json"


### PR DESCRIPTION
This PR adds several features, hopefully you will want them all!  If separate PRs are preferred please let me know.

1. Updates "user" to "runas" in cmd.run states to clear the deprecation warning.
2. Flushes out docker.client.service with additional parameters.
3. Adds --with-registry-auth to stack like service already has.
4. Adds support for extension-fields templating to docker-compose.yml -- https://docs.docker.com/compose/compose-file/#extension-fields
5. When a password is used in cmd.run it is sent as an environment variable so that it does not show up in the Salt minion logs.