### PR TITLE
Improvements for swarm

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -78,8 +78,15 @@ will initialize the swarm.
           host: 192.168.1.5
           port: 2377
 
+          # Optionally, you can make the discovery faster by providing slave
+          # nodes a target to the master node.
+          # If a target is specified and any of the targetted nodes expose a
+          # join token in their grains, this token will be used to join the
+          # cluster, ignoring any advertise address.
+          # target: 'swarm-master*'
+
 The token to join to the master node is obtained from grains using
-``salt.mine``.  In case of any ``join_token undefined`` issues, verify that
+``salt.mine``.  In case of any ``join_token unknown`` issues, verify that
 you have ``docker_swarm_`` grains available.
 
 Docker client configuration samples

--- a/_grains/docker_swarm.py
+++ b/_grains/docker_swarm.py
@@ -11,7 +11,12 @@ def main():
 
     if os.path.exists('/var/lib/docker/swarm'):
         try:
-            inspect = json.loads(subprocess.check_output(["docker", "node", "inspect", "self"], stderr=subprocess.STDOUT).strip())[0]
+            inspect = json.loads(
+                subprocess.check_output(
+                    ["docker", "node", "inspect", "self"],
+                    stderr=subprocess.STDOUT,
+                ).decode("utf-8").strip()
+            )[0]
         except subprocess.CalledProcessError:
             return None
 
@@ -23,8 +28,14 @@ def main():
 
         if output['docker_swarm_role'] == 'manager':
             output["docker_swarm_tokens"] = {
-                'worker': subprocess.check_output(["docker", "swarm", "join-token", "-q", "worker"]).strip(),
-                'manager': subprocess.check_output(["docker", "swarm", "join-token", "-q", "manager"]).strip()
+                'worker': (
+                    subprocess.check_output(
+                        ["docker", "swarm", "join-token", "-q", "worker"],
+                    ).decode("utf-8").strip()
+                ),
+                'manager': subprocess.check_output(
+                    ["docker", "swarm", "join-token", "-q", "manager"],
+                ).decode("utf-8").strip()
             }
 
         if os.path.exists('/var/lib/docker/swarm/state.json'):

--- a/docker/swarm.sls
+++ b/docker/swarm.sls
@@ -83,7 +83,7 @@ docker_swarm_join:
         {{ swarm.master.host }}:{{ swarm.master.port }}
     - unless:
       - "test -e /var/lib/docker/swarm/state.json"
-      - "grep -q node_id /var/lib/docker/swarm/state.json"
+      - "grep -Eq '\"(node_id|addr)\"' /var/lib/docker/swarm/state.json"
     - require:
       - service: docker_service
 


### PR DESCRIPTION
- Allow targeting master node. I need this mainly for one reason: my worker node joins the master node using a hostname rather than an IP. Therefore the advertising address will never match the master node address declared in pillars.
- Fix swarm formula on python3. It would fail because `subprocess.check_output` returns bytes while `json.loads` expects a string.
- Fix detection of nodes that have already joined the cluster. My `/var/lib/docker/swarm/state.json` file doesn't have a `node_id` key but only an `addr` key.

This PR worked against my cluster. Please feel free to ask should you have any question.