### PR TITLE
Prefer `yaml.safe_load()`

### DIFF
--- a/_grains/docker_swarm.py
+++ b/_grains/docker_swarm.py
@@ -40,13 +40,13 @@ def main():
 
         if os.path.exists('/var/lib/docker/swarm/state.json'):
             with open('/var/lib/docker/swarm/state.json') as fh:
-                state = yaml.load(fh)
+                state = yaml.safe_load(fh)
                 for key, value in state[0].items():
                     output["docker_swarm_%s" % key] = value
 
         if os.path.exists('/var/lib/docker/swarm/docker-state.json'):
             with open('/var/lib/docker/swarm/docker-state.json') as fh:
-                state = yaml.load(fh)
+                state = yaml.safe_load(fh)
                 for key, value in state.items():
                     output["docker_swarm_%s" % key] = value
 


### PR DESCRIPTION
`yaml.load()` is vulnerable to arbitrary object deserialization and
should not be used. (https://nvd.nist.gov/vuln/detail/CVE-2017-18342)

Morever, this function is now deprecated https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation